### PR TITLE
Fix typo in comment

### DIFF
--- a/src/Tawfekh_editor/Tawfekh_editor.java
+++ b/src/Tawfekh_editor/Tawfekh_editor.java
@@ -739,7 +739,7 @@ public class Tawfekh_editor extends javax.swing.JFrame implements ActionListener
     }
 
     private void btnUploadBgActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnUploadBgActionPerformed
-        // Updoad New Background.
+        // Upload new background.
         try {
             JFileChooser chooser = new JFileChooser();
             chooser.showOpenDialog(null);


### PR DESCRIPTION
## Summary
- fix misspelled comment in `btnUploadBgActionPerformed`

## Testing
- `ant -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431ccd37e08330aa25c8ec8da97101